### PR TITLE
feat: Implement to download conflict files through protocol

### DIFF
--- a/pkg/core/server/service.go
+++ b/pkg/core/server/service.go
@@ -72,6 +72,7 @@ func NewService(repo *badger.Badger, serverRepository Repository) (Service, erro
 	proto.RecvTransactionHandleFunc(types.GETROOTDIRS, syncHandler.GetRemoteDirs)
 	proto.RecvTransactionHandleFunc(types.PLEASESYNC, syncHandler.PleaseSync)
 	proto.RecvTransactionHandleFunc(types.CONFLICTLIST, syncHandler.AskConflictList)
+	proto.RecvTransactionHandleFunc(types.CONFLICTDOWNLOAD, syncHandler.ConflictDownload)
 	proto.RecvTransactionHandleFunc(types.CHOOSEONE, syncHandler.ChooseOne)
 	proto.RecvTransactionHandleFunc(types.RESCAN, syncHandler.Rescan)
 	proto.RecvTransactionHandleFunc(types.SHOWHISTORY, historyHandler.ShowHistory)

--- a/pkg/core/sharing/ports.go
+++ b/pkg/core/sharing/ports.go
@@ -1,9 +1,14 @@
 package sharing
 
+import "github.com/quic-s/quics/pkg/types"
+
 type Repository interface {
-	SaveNewDownloadLink(link string) error
+	SaveLink(sharing *types.Sharing) error
+	GetLink(link string) (*types.Sharing, error)
+	DeleteLink(link string) error
 }
 
 type Service interface {
-	CreateLink(UUID string, afterPath string, count uint64) (string, error)
+	CreateLink(request *types.ShareReq) (*types.ShareRes, error)
+	DeleteLink(request *types.StopShareReq) (*types.StopShareRes, error)
 }

--- a/pkg/core/sharing/service.go
+++ b/pkg/core/sharing/service.go
@@ -1,19 +1,89 @@
 package sharing
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/quic-s/quics/pkg/core/history"
+	"github.com/quic-s/quics/pkg/core/sync"
+	"github.com/quic-s/quics/pkg/types"
+)
+
 type SharingService struct {
+	historyRepository history.Repository
+	syncRepository    sync.Repository
 	sharingRepository Repository
 }
 
 const (
-	PrefixLink = "http://"
+	// FIXME: this link is for testing purposes only
+	PrefixLink = "http://localhost:6121/api/v1/download/files"
 )
 
-func NewService(sharingRepository Repository) *SharingService {
+func NewService(historyRepository history.Repository, syncRepository sync.Repository, sharingRepository Repository) *SharingService {
 	return &SharingService{
+		historyRepository: historyRepository,
+		syncRepository:    syncRepository,
 		sharingRepository: sharingRepository,
 	}
 }
 
-func (ss *SharingService) CreateLink(UUID string, afterPath string, count uint64) (string, error) {
-	return "", nil
+func (ss *SharingService) CreateLink(request *types.ShareReq) (*types.ShareRes, error) {
+	file, err := ss.syncRepository.GetFileByPath(request.AfterPath)
+	if err != nil {
+		return nil, err
+	}
+
+	fileHistory, err := ss.historyRepository.GetFileHistory(file.AfterPath, file.LatestSyncTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	// make link
+	paramUUID := "?uuid=" + strings.ToLower(request.UUID)
+	paramFile := "&file=" + strings.ToLower(strings.ReplaceAll(file.AfterPath, "/", "-"))
+	paramVersion := "&version=" + fmt.Sprint(file.LatestSyncTimestamp)
+	link := PrefixLink + paramUUID + paramFile + paramVersion
+
+	// save link to database
+	sharing := &types.Sharing{
+		Link:     link,
+		Count:    0,
+		MaxCount: uint(request.MaxCnt),
+		Owner:    request.UUID,
+		File:     *fileHistory,
+	}
+
+	err = ss.sharingRepository.SaveLink(sharing)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.ShareRes{
+		Link: link,
+	}, nil
+}
+
+func (ss *SharingService) DeleteLink(request *types.StopShareReq) (*types.StopShareRes, error) {
+	// get sharing data using link
+	sharing, err := ss.sharingRepository.GetLink(request.Link)
+	if err != nil {
+		return nil, err
+	}
+
+	// check if the user is the owner of the link
+	if sharing.Owner != request.UUID {
+		return nil, errors.New("not authorized")
+	}
+
+	// delete link
+	err = ss.sharingRepository.DeleteLink(request.Link)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.StopShareRes{
+		UUID: request.UUID,
+	}, nil
 }

--- a/pkg/core/sync/ports.go
+++ b/pkg/core/sync/ports.go
@@ -48,6 +48,9 @@ type Service interface {
 	GetFileByPath(afterPath string) (*types.File, error)
 
 	RollbackFileByHistory(request *types.RollBackReq) (*types.RollBackRes, error)
+
+	GetStagingNum(request *types.AskStagingNumReq) (*types.AskStagingNumRes, []string, error)
+	GetConflictFiles(request *types.AskStagingNumReq, conflictFilePaths []string) ([]*types.ConflictDownloadReq, []string, error)
 }
 
 type SyncDirAdapter interface {

--- a/pkg/network/http/sharing.go
+++ b/pkg/network/http/sharing.go
@@ -1,7 +1,8 @@
 package http
 
 import (
-	"github.com/gorilla/mux"
+	"net/http"
+
 	"github.com/quic-s/quics/pkg/core/sharing"
 )
 
@@ -15,6 +16,6 @@ func NewSharingHandler(sharingService sharing.Service) *SharingHandler {
 	}
 }
 
-func (handler *SharingHandler) SetupRoutes(r *mux.Router) {
-
+func (sh *SharingHandler) SetupRoutes(mux *http.ServeMux) http.Handler {
+	return mux
 }

--- a/pkg/network/qp/sharing.go
+++ b/pkg/network/qp/sharing.go
@@ -1,7 +1,11 @@
 package qp
 
 import (
+	"log"
+
+	qp "github.com/quic-s/quics-protocol"
 	"github.com/quic-s/quics/pkg/core/sharing"
+	"github.com/quic-s/quics/pkg/types"
 )
 
 type SharingHandler struct {
@@ -12,4 +16,76 @@ func NewSharingHandler(sharingService sharing.Service) *SharingHandler {
 	return &SharingHandler{
 		sharingService: sharingService,
 	}
+}
+
+func (sh *SharingHandler) StartSharing(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) error {
+	log.Println("quics: message received ", conn.Conn.RemoteAddr().String())
+
+	data, err := stream.RecvBMessage()
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	request := &types.ShareReq{}
+	if err := request.Decode(data); err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	response, err := sh.sharingService.CreateLink(request)
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	data, err = response.Encode()
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	err = stream.SendBMessage(data)
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	return nil
+}
+
+func (sh *SharingHandler) StopSharing(conn *qp.Connection, stream *qp.Stream, transactionName string, transactionID []byte) error {
+	log.Println("quics: message received ", conn.Conn.RemoteAddr().String())
+
+	data, err := stream.RecvBMessage()
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	request := &types.StopShareReq{}
+	if err := request.Decode(data); err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	response, err := sh.sharingService.DeleteLink(request)
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	data, err = response.Encode()
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	err = stream.SendBMessage(data)
+	if err != nil {
+		log.Println("quics: ", err)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/repository/badger/sharing.go
+++ b/pkg/repository/badger/sharing.go
@@ -1,6 +1,9 @@
 package badger
 
-import "github.com/dgraph-io/badger/v3"
+import (
+	"github.com/dgraph-io/badger/v3"
+	"github.com/quic-s/quics/pkg/types"
+)
 
 const (
 	PrefixSharing string = "sharing_"
@@ -10,6 +13,63 @@ type SharingRepository struct {
 	db *badger.DB
 }
 
-func (sr *SharingRepository) SaveNewDownloadLink(link string) error {
+func (sr *SharingRepository) SaveLink(sharing *types.Sharing) error {
+	key := []byte(PrefixSharing + sharing.Link)
+
+	err := sr.db.Update(func(txn *badger.Txn) error {
+		err := txn.Set(key, sharing.Encode())
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sr *SharingRepository) GetLink(link string) (*types.Sharing, error) {
+	key := []byte(PrefixSharing + link)
+
+	sharing := &types.Sharing{}
+
+	err := sr.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if err != nil {
+			return err
+		}
+
+		val, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+
+		if err := sharing.Decode(val); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return sharing, nil
+}
+
+func (sr *SharingRepository) DeleteLink(link string) error {
+	key := []byte(PrefixSharing + link)
+
+	err := sr.db.Update(func(txn *badger.Txn) error {
+		err := txn.Delete(key)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/types/db.go
+++ b/pkg/types/db.go
@@ -77,12 +77,11 @@ type Conflict struct {
 
 // Sharing is used to store the file download information
 type Sharing struct {
-	Id       uint // key
+	Link     string // key
 	Count    uint
 	MaxCount uint
-	Link     string
 	Owner    string
-	File     FileHistory // to share file at point that client wanted in time
+	File     FileHistory // to share file at point that client wanted
 }
 
 func (client *Client) Encode() []byte {

--- a/pkg/types/message.go
+++ b/pkg/types/message.go
@@ -7,25 +7,26 @@ import (
 )
 
 const (
-	REGISTERCLIENT  = "REGISTERCLIENT"
-	REGISTERROOTDIR = "REGISTERROOTDIR"
-	SYNCROOTDIR     = "SYNCROOTDIR"
-	GETROOTDIRS     = "GETROOTDIRS"
-	PLEASESYNC      = "PLEASESYNC"
-	MUSTSYNC        = "MUSTSYNC"
-	FORCESYNC       = "FORCESYNC"
-	CONFLICT        = "CONFLICT"
-	CONFLICTLIST    = "CONFLICTLIST"
-	CHOOSEONE       = "CHOOSEONE"
-	FULLSCAN        = "FULLSCAN"
-	RESCAN          = "RESCAN"
-	NEEDCONTENT     = "NEEDCONTENT"
-	PING            = "PING"
-	ROLLBACK        = "ROLLBACK"
-	SHOWHISTORY     = "SHOWHISTORY"
-	DOWNLOAD        = "DOWNLOAD"
-	DOWNLOADHISTORY = "DOWNLOADHISTORY"
-	SHARING         = "SHARING"
+	REGISTERCLIENT   = "REGISTERCLIENT"
+	REGISTERROOTDIR  = "REGISTERROOTDIR"
+	SYNCROOTDIR      = "SYNCROOTDIR"
+	GETROOTDIRS      = "GETROOTDIRS"
+	PLEASESYNC       = "PLEASESYNC"
+	MUSTSYNC         = "MUSTSYNC"
+	FORCESYNC        = "FORCESYNC"
+	CONFLICT         = "CONFLICT"
+	CONFLICTLIST     = "CONFLICTLIST"
+	CONFLICTDOWNLOAD = "CONFLICTDOWNLOAD"
+	CHOOSEONE        = "CHOOSEONE"
+	FULLSCAN         = "FULLSCAN"
+	RESCAN           = "RESCAN"
+	NEEDCONTENT      = "NEEDCONTENT"
+	PING             = "PING"
+	ROLLBACK         = "ROLLBACK"
+	SHOWHISTORY      = "SHOWHISTORY"
+	DOWNLOAD         = "DOWNLOAD"
+	DOWNLOADHISTORY  = "DOWNLOADHISTORY"
+	SHARING          = "SHARING"
 )
 
 type MessageData interface {
@@ -284,6 +285,22 @@ type ShareReq struct {
 
 type ShareRes struct {
 	Link string
+}
+
+type AskStagingNumReq struct {
+	UUID      string
+	AfterPath string
+}
+
+type AskStagingNumRes struct {
+	UUID        string
+	ConflictNum uint64
+}
+
+type ConflictDownloadReq struct {
+	UUID      string // client UUID who want to download
+	Candidate string // coflict file's UUID from FileHistory (stagingFile)
+	AfterPath string // conflict file's AfterPath
 }
 
 func (clientRegisterReq *ClientRegisterReq) Encode() ([]byte, error) {
@@ -965,4 +982,52 @@ func (shareRes *ShareRes) Decode(data []byte) error {
 	buffer := bytes.NewBuffer(data)
 	decoder := gob.NewDecoder(buffer)
 	return decoder.Decode(shareRes)
+}
+
+func (askStagingNumReq *AskStagingNumReq) Encode() ([]byte, error) {
+	buffer := bytes.Buffer{}
+	encoder := gob.NewEncoder(&buffer)
+	if err := encoder.Encode(askStagingNumReq); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (askStagingNumReq *AskStagingNumReq) Decode(data []byte) error {
+	buffer := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buffer)
+	return decoder.Decode(askStagingNumReq)
+}
+
+func (askStagingNumRes *AskStagingNumRes) Encode() ([]byte, error) {
+	buffer := bytes.Buffer{}
+	encoder := gob.NewEncoder(&buffer)
+	if err := encoder.Encode(askStagingNumRes); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (askStagingNumRes *AskStagingNumRes) Decode(data []byte) error {
+	buffer := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buffer)
+	return decoder.Decode(askStagingNumRes)
+}
+
+func (conflictDownloadReq *ConflictDownloadReq) Encode() ([]byte, error) {
+	buffer := bytes.Buffer{}
+	encoder := gob.NewEncoder(&buffer)
+	if err := encoder.Encode(conflictDownloadReq); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (conflictDownloadReq *ConflictDownloadReq) Decode(data []byte) error {
+	buffer := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buffer)
+	return decoder.Decode(conflictDownloadReq)
 }

--- a/pkg/types/message.go
+++ b/pkg/types/message.go
@@ -26,7 +26,8 @@ const (
 	SHOWHISTORY      = "SHOWHISTORY"
 	DOWNLOAD         = "DOWNLOAD"
 	DOWNLOADHISTORY  = "DOWNLOADHISTORY"
-	SHARING          = "SHARING"
+	STARTSHARING     = "STARTSHARING"
+	STOPSHARING      = "STOPSHARING"
 )
 
 type MessageData interface {
@@ -285,6 +286,15 @@ type ShareReq struct {
 
 type ShareRes struct {
 	Link string
+}
+
+type StopShareReq struct {
+	UUID string
+	Link string
+}
+
+type StopShareRes struct {
+	UUID string
 }
 
 type AskStagingNumReq struct {
@@ -982,6 +992,38 @@ func (shareRes *ShareRes) Decode(data []byte) error {
 	buffer := bytes.NewBuffer(data)
 	decoder := gob.NewDecoder(buffer)
 	return decoder.Decode(shareRes)
+}
+
+func (stopShareReq *StopShareReq) Encode() ([]byte, error) {
+	buffer := bytes.Buffer{}
+	encoder := gob.NewEncoder(&buffer)
+	if err := encoder.Encode(stopShareReq); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (stopShareReq *StopShareReq) Decode(data []byte) error {
+	buffer := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buffer)
+	return decoder.Decode(stopShareReq)
+}
+
+func (stopShareRes *StopShareRes) Encode() ([]byte, error) {
+	buffer := bytes.Buffer{}
+	encoder := gob.NewEncoder(&buffer)
+	if err := encoder.Encode(stopShareRes); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (stopShareRes *StopShareRes) Decode(data []byte) error {
+	buffer := bytes.NewBuffer(data)
+	decoder := gob.NewDecoder(buffer)
+	return decoder.Decode(stopShareRes)
 }
 
 func (askStagingNumReq *AskStagingNumReq) Encode() ([]byte, error) {


### PR DESCRIPTION
**Which issue(s) this PR is related**:
Related: #39

**What this PR does / Why we need it**:
A Client can request the conflict files (with contents) to the server.
And the server response the files to the client.
- send the count of conflict files to the client
- send the conflict files to the client

**Checklist**:
- [ ] Added relevant tests or not required
- [x] Didn't break anything